### PR TITLE
微調整色々

### DIFF
--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -2,7 +2,7 @@ $(function(){
   function buildChild(){
     // 2つ目のセレクトボックスの外枠
     var html = `<div class="select-warp">
-    <select class="select-default" id="children-form" name="item[items_categories_attributes][0][category_id]"><option value="">---</option>
+    <select class="select-default" id="children-form" name="item[items_categories_attributes][1][category_id]"><option value="">---</option>
     </select>
     <i class="fas fa-angle-down"></i>
     </div>`
@@ -16,7 +16,7 @@ $(function(){
   function buildGrandChild(){
     // 3つ目のセレクトボックスの外枠
     var html = `<div class="select-warp">
-    <select class="select-default" id="grand-children-form" name="item[items_categories_attributes][0][category_id]"><option value="">---</option>
+    <select class="select-default" id="grand-children-form" name="item[items_categories_attributes][2][category_id]"><option value="">---</option>
     </select>
     <i class="fas fa-angle-down"></i>
     </div>`

--- a/app/assets/stylesheets/modules/toppage.scss
+++ b/app/assets/stylesheets/modules/toppage.scss
@@ -10,7 +10,7 @@
       letter-spacing: 2px;
     }
     .common-container {
-      width: 940px;
+      width: 960px;
       margin: 0 auto;
       &__title {
         font-size: 22px;
@@ -28,9 +28,9 @@
       .wrapper {
         width: auto;
         margin: 0 auto;
-        display: flex;
         padding-top: 26px;
         .section {
+          float: left;
           margin: 0 0 0 20px;
           width: 213px;
           background-color: white;
@@ -75,6 +75,7 @@
         }
       }
       .more {
+        clear: both;
         padding: 20px 0 30px;
         width: 99.5%;
         text-align: right;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,13 +8,13 @@ class ItemsController < ApplicationController
     @picup_category_items1 = Category.find(1).items.order("created_at DESC").limit(4)
 
     # カテゴリー新着2
-    @picup_category2 = Category.find(2).items.order("created_at DESC").limit(4)
+    @picup_category_items2 = Category.find(2).items.order("created_at DESC").limit(4)
 
     # カテゴリー新着3
-    @picup_category3 = Category.find(3).items.order("created_at DESC").limit(4)
+    @picup_category_items3 = Category.find(3).items.order("created_at DESC").limit(4)
 
     # カテゴリー新着4
-    @picup_category4 = Category.find(4).items.order("created_at DESC").limit(4)
+    @picup_category_items4 = Category.find(4).items.order("created_at DESC").limit(4)
 
     # # ブランド新着1
     # @picup_brand1 = Brand.find(1).items.order("created_at DESC").limit(4)

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,7 +1,8 @@
 = render 'layouts/header'
 
 .credit-card-create
-  .bread-crumbs
+  - breadcrumb :card_edit
+  = render "render/bread-crumbs"
   .l-container.clearfix
     .l-content
       %section.l-chapter-container

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -1,7 +1,8 @@
 = render 'layouts/header'
 
 .credit-card-show
-  .bread-crumbs
+  - breadcrumb :card_edit
+  = render "render/bread-crumbs"
   .l-container.clearfix
     .l-content
       %section.l-chapter-container

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -12,30 +12,30 @@
           .more
             = link_to 'すべての商品を見る','#', class: 'menu-btn'
 
-    - if (@picup_category2.length != 0)
+    - if (@picup_category_items2.length != 0)
       %section.common-container.clearfix
         %h3.common-container__title
-          = link_to "#{@picup_category2[0].categories[0].name} 新着アイテム",'#', class: 'btn'
+          = link_to "#{@picup_category_items2[0].categories[0].name} 新着アイテム",'#', class: 'btn'
           .wrapper.clearfix
-            = render partial: 'pickup', collection: @picup_category2, as: :item
+            = render partial: 'pickup', collection: @picup_category_items2, as: :item
           .more
             = link_to 'すべての商品を見る','#', class: 'menu-btn'
 
-    - if (@picup_category3.length != 0)
+    - if (@picup_category_items3.length != 0)
       %section.common-container.clearfix
         %h3.common-container__title
-          = link_to "#{@picup_category3[0].categories[0].name} 新着アイテム",'#', class: 'btn'
+          = link_to "#{@picup_category_items3[0].categories[0].name} 新着アイテム",'#', class: 'btn'
           .wrapper.clearfix
-            = render partial: 'pickup', collection: @picup_category3, as: :item
+            = render partial: 'pickup', collection: @picup_category_items3, as: :item
           .more
             = link_to 'すべての商品を見る','#', class: 'menu-btn'
 
-    - if (@picup_category4.length != 0)
+    - if (@picup_category_items4.length != 0)
       %section.common-container.clearfix
         %h3.common-container__title
-          = link_to "#{@picup_category4[0].categories[0].name} 新着アイテム",'#', class: 'btn'
+          = link_to "#{@picup_category_items4[0].categories[0].name} 新着アイテム",'#', class: 'btn'
           .wrapper.clearfix
-            = render partial: 'pickup', collection: @picup_category4, as: :item
+            = render partial: 'pickup', collection: @picup_category_items4, as: :item
           .more
             = link_to 'すべての商品を見る','#', class: 'menu-btn'
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,7 @@
 = render 'layouts/header'
 
 .product-details
+  - breadcrumb :item, @item
   = render 'render/bread-crumbs'
   .default-container
     .item-box-container
@@ -35,15 +36,15 @@
             .tr
               .th 商品の状態
               .td 
-                = @item.item_status
+                = @item.item_status_i18n
             .tr
               .th 配送料の負担
               .td
-                = @item.shipment.cost_payer
+                = @item.shipment.cost_payer_i18n
             .tr
               .th 配送の方法
               .td
-                = @item.shipment.method
+                = @item.shipment.method_i18n
             .tr
               .th 配送元地域
               .td
@@ -51,7 +52,7 @@
             .tr
               .th 発送日の目安
               .td
-                = @item.shipment.days
+                = @item.shipment.days_i18n
       .item-price-box
         %span.item-price
           ￥

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -25,3 +25,8 @@ crumb :personal_edit do
   link '本人情報の登録'
   parent :user
 end
+
+# アイテム詳細ページ用
+crumb :item do |item|
+  link "#{item.name}"
+end


### PR DESCRIPTION
# what
アイテム出品時にカテゴリーが１つしか保存されない問題の修正
アイテム詳細ページ、クレジットカードページのパンくず追加
アイテム詳細ページのshipmentをi18n対応
トップページのコントローラー（インスタンス変数）の記述を修正

# why
バグ等修正のため