### PR TITLE
商品削除編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,9 +58,9 @@ class ItemsController < ApplicationController
   def show
   end
 
-  def destroy    
+  def destroy
     @item.destroy
-    redirect_to root_path, notice: '商品を削除しました'
+    redirect_to root_path
   end
 
   def search

--- a/db/migrate/20190610141814_change_shipment_id_to_items.rb
+++ b/db/migrate/20190610141814_change_shipment_id_to_items.rb
@@ -1,5 +1,4 @@
 class ChangeShipmentIdToItems < ActiveRecord::Migration[5.2]
   def change
-    add_foreign_key :items, :shipments
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,7 +133,6 @@ ActiveRecord::Schema.define(version: 2019_06_12_024130) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "items", "shipments"
   add_foreign_key "personals", "users"
   add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
# What
商品削除機能を完成させる

# Why
商品削除でエラーが出ているため

shipmentの外部キーを外したら削除出来るようになりました。
関連したテーブルの情報も一緒に消えるようになっています。