### PR TITLE
商品売り切れ時の処理（商品詳細ページ）

### DIFF
--- a/app/assets/stylesheets/modules/items_show.scss
+++ b/app/assets/stylesheets/modules/items_show.scss
@@ -35,6 +35,38 @@
               position: relative;
               overflow: hidden;
               clear: both;
+              .item-soldout__badge::after {
+                @media screen and (min-width: 768px) {
+                  border-width: 100px 100px 0 0;
+                }
+                border-width: 65px 65px 0 0;
+                border-color: #ea352d transparent transparent transparent;
+                display: block;
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                z-index: 1;
+                width: 0;
+                height: 0;
+                border-style: solid;
+              }
+              .item-soldout__badge>div {
+                @media screen and (min-width: 768px) {
+                  top: 20px;
+                  font-size: 22px;
+                }
+                top: 14px;
+                font-size: 16px;
+                position: absolute;
+                left: 0;
+                z-index: 2;
+                color: #fff;
+                -webkit-transform: rotate(-45deg);
+                transform: rotate(-45deg);
+                letter-spacing: 2px;
+                font-weight: 600;
+                }
               .owl-dot {
                 width: 60px;
                 height: 60px;
@@ -137,7 +169,18 @@
           text-decoration: none;
           font-size: 24px
           }
+        .sold-btn {
+          height: 60px;
+          line-height: 60px;
+          background: #aaa;
+          color: #fff;
+          text-align: center;
+          font-weight: 600;
+          text-decoration: none;
+          font-size: 24px
+          
         }
+      }
       .item-description {
         background: #fff;
         width: 650px;

--- a/app/views/items/_soldout.html.haml
+++ b/app/views/items/_soldout.html.haml
@@ -1,0 +1,17 @@
+%section.section
+  = link_to item_path(item.id) do
+    %figure.section__image
+      = image_tag @item.images[0].variant(combine_options:{resize:"213x213^",crop:"213x213+0+0",gravity: :center}).processed, class: 'owl-dot'
+      -if (@item.buyer_id != nil)
+        %figcaption
+          .item-soldout__badge
+            %div SOLD
+    -# .content
+    -#   %h3.content__title.font-2 #{item.name}
+    -#   .item-box
+    -#     .item-box__price.font-5 ¥#{item.price.to_s(:delimited, delimiter: ',')}
+    -#     .item-box__mask.font-2
+    -#       %i.far.fa-heart
+    -#       %span #{item.like}
+    -#   %p.content__lead (税込)
+

--- a/app/views/items/_soldout.html.haml
+++ b/app/views/items/_soldout.html.haml
@@ -6,12 +6,4 @@
         %figcaption
           .item-soldout__badge
             %div SOLD
-    -# .content
-    -#   %h3.content__title.font-2 #{item.name}
-    -#   .item-box
-    -#     .item-box__price.font-5 ¥#{item.price.to_s(:delimited, delimiter: ',')}
-    -#     .item-box__mask.font-2
-    -#       %i.far.fa-heart
-    -#       %span #{item.like}
-    -#   %p.content__lead (税込)
-
+            

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,6 +11,7 @@
           .item-photo
             .gallery
               = image_tag @item.images[0], class: 'owl', width: "300px", height: "300px";
+              = render partial: 'soldout', collection: @item.images, as: :item
               - @item.images.each do |image|
                 = image_tag image, class: 'owl-dot', width: "60px", height: "60px";
           .item-detail-table
@@ -62,8 +63,10 @@
         %span.item-shipping-fee
           送料込み
       .item-edit
-        -if @item.seller.id != current_user.id
-          = link_to '購入画面に進む', item_path(params[:id]), class: 'item-buy-btn'  
+        -if @item.seller.id != current_user.id && @item.buyer_id == nil
+          = link_to '購入画面に進む', item_path(params[:id]), class: 'item-buy-btn'
+        -if @item.buyer_id != nil
+          = link_to '売り切れました', '#', class: 'item-buy-btn sold-btn', href: "javascript:void(0)"
         = render 'render/item-descliption'
       -if @item.seller.id == current_user.id
         = link_to "商品の編集", edit_item_path, class: 'edit-btn'
@@ -76,3 +79,4 @@
         %button{type: "submit", class: "message-submit"}
           .span コメントする
   = render 'layouts/footer'
+


### PR DESCRIPTION
# What
商品詳細ページで、商品が売り切れた時にsoldoutタグがつくようにする。
購入画面へ進むボタンのかわりに売り切れましたと表示されるようにする。

# Why
必要なので

https://gyazo.com/4f932abd6bb94420aadf858cb1984eb8